### PR TITLE
Fixed 'syntax error in tsquery' SQL error when wrong keyword passed.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ice-blockchain/subzero v1.411.0
+	github.com/ice-blockchain/subzero v1.412.0
 	github.com/ice-blockchain/wintr v1.162.0
 	github.com/imroc/req/v3 v3.55.0
 	github.com/jellydator/ttlcache/v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -448,8 +448,8 @@ github.com/ice-blockchain/go-nostr v0.42.3-ion.0.20250618110920-2070eacdb5f5 h1:
 github.com/ice-blockchain/go-nostr v0.42.3-ion.0.20250618110920-2070eacdb5f5/go.mod h1:or80JBz1VHXxKN5qXBNYFooWcfjUPIQzbNUVZ7FTFzo=
 github.com/ice-blockchain/go/src v0.0.0-20250625091122-356c0c7d1830 h1:FymrVSpOD6rKyZ97MJr5Xu2ZP29EqTKpdMqTf2DrMgU=
 github.com/ice-blockchain/go/src v0.0.0-20250625091122-356c0c7d1830/go.mod h1:pVzkmaIwkLaJ5cKPHPtuKyxaXiTsa/V7kbbgLmsr4Hw=
-github.com/ice-blockchain/subzero v1.411.0 h1:MjSVKd2YfeQ9IpieFxHHRMCN5ZR/8PbQF3r6Jzy3eB4=
-github.com/ice-blockchain/subzero v1.411.0/go.mod h1:rfyCly21w7FFnakoatZcPRBvjmFDGB8s0Jod53ne3yk=
+github.com/ice-blockchain/subzero v1.412.0 h1:eUscxKnubvGm/CjBkjQ77CmWWtSeLUNF9R5JAXy9A9M=
+github.com/ice-blockchain/subzero v1.412.0/go.mod h1:rfyCly21w7FFnakoatZcPRBvjmFDGB8s0Jod53ne3yk=
 github.com/ice-blockchain/wintr v1.162.0 h1:rWADHZWpHchNj6T4O8+tSEigmoFgcGr2dLOYSmqHBLI=
 github.com/ice-blockchain/wintr v1.162.0/go.mod h1:90eXnhvMZ2KhK+pghah/PA2+spMZqOis9P1yYvav03I=
 github.com/icholy/digest v1.1.0 h1:HfGg9Irj7i+IX1o1QAmPfIBNu/Q5A5Tu3n/MED9k9H4=

--- a/hashtag-statistics/contract.go
+++ b/hashtag-statistics/contract.go
@@ -28,11 +28,11 @@ var (
 	//go:embed DDL.sql
 	ddl string
 
-	hashtagRegex = regexp.MustCompile(`#[a-zA-Z0-9_]+`)
+	hashtagRegex      = regexp.MustCompile(`#[a-zA-Z0-9_]+`)
+	validKeywordChars = regexp.MustCompile(`^[a-zA-Z0-9_\s]+$`)
 )
 
 type (
-	hashtag     = string
 	topHashtags struct {
 		Hashtags []string `db:"hashtags"`
 	}

--- a/hashtag-statistics/hashtagstatistics.go
+++ b/hashtag-statistics/hashtagstatistics.go
@@ -105,6 +105,9 @@ func (h *hashtagStatisticsRepository) GetTopHashtags(ctx context.Context, limit 
 }
 
 func (h *hashtagStatisticsRepository) GetTopHashtagsByKeyword(ctx context.Context, keyword string, limit int) ([]string, error) {
+	if !validKeywordChars.MatchString(keyword) {
+		return []string{}, nil
+	}
 	stmt := `
 		SELECT array_agg(x.hashtag) hashtags
 		FROM (


### PR DESCRIPTION
```
ERROR:[wintr/storage/v2]call failed. retrying in 1.499886509s... : scanning all: scany: rows final error: ERROR: syntax error in tsquery: "x(tw:*" (SQLSTATE 42601)
```