### PR TITLE
Increase version triggers fix

### DIFF
--- a/accounts/DDL.sql
+++ b/accounts/DDL.sql
@@ -92,10 +92,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- TODO: Remove this after migration to all environments
-DROP TRIGGER IF EXISTS global_accounts_insert_version_trigger ON global_accounts;
-
-CREATE OR REPLACE TRIGGER global_accounts_insert_delete_version_trigger
+CREATE OR REPLACE TRIGGER global_accounts_insert_version_trigger
 AFTER INSERT OR DELETE ON global_accounts
 FOR EACH ROW
 EXECUTE FUNCTION increment_global_accounts_version();
@@ -122,10 +119,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- TODO: Remove this after migration to all environments
-DROP TRIGGER IF EXISTS nsfw_accounts_insert_version_trigger ON nsfw_accounts;
-
-CREATE OR REPLACE TRIGGER nsfw_accounts_insert_delete_version_trigger
+CREATE OR REPLACE TRIGGER nsfw_accounts_insert_version_trigger
 AFTER INSERT OR DELETE ON nsfw_accounts
 FOR EACH ROW
 EXECUTE FUNCTION increment_nsfw_accounts_version();


### PR DESCRIPTION
Spitted increment trigger to different triggers for global_accounts and nfsw_content tables not to have version increase on ANY user cascade delete, but ONLY on cascade delete of exisint user at global_accounts/nfsw_content tables.